### PR TITLE
Add procedure definitions

### DIFF
--- a/src/compiler/backend/code_generator.rs
+++ b/src/compiler/backend/code_generator.rs
@@ -404,6 +404,22 @@ impl CodeGenerator {
 
     fn emit_definition(&mut self, definition: &DefinitionExpression) -> Result<()> {
         match definition {
+            DefinitionExpression::DefineProcedure(id, lambda_expr, _loc) => {
+                // name of procedure is part is the label of the lambda expression
+                self.emit_lambda(lambda_expr)?;
+                let id_sym = self.sym(&id.string());
+                let const_addr = self.current_chunk().add_constant(id_sym);
+
+                if let Target::TopLevel = self.target {
+                    self.emit_instruction(
+                        Instruction::Define(const_addr),
+                        &definition.source_location(),
+                    )
+                } else {
+                    // internal define sets a local variable instead
+                    todo!()
+                }
+            }
             DefinitionExpression::DefineSimple(id, expr, _loc) => {
                 self.emit_instructions(expr, &Context::NonTail)?;
                 let id_sym = self.sym(&id.string());

--- a/src/compiler/frontend/parser/expression/lambda.rs
+++ b/src/compiler/frontend/parser/expression/lambda.rs
@@ -100,7 +100,7 @@ pub fn do_parse_lambda(
     }
 }
 
-fn parse_formals(datum: &Datum) -> Result<Formals> {
+pub fn parse_formals(datum: &Datum) -> Result<Formals> {
     match datum.sexp() {
         Sexp::List(ls) => {
             let identifiers: Result<Vec<Identifier>> =

--- a/src/compiler/frontend/parser/sexp/datum.rs
+++ b/src/compiler/frontend/parser/sexp/datum.rs
@@ -52,6 +52,13 @@ impl Sexp {
         Self::ImproperList(elts, Box::new(element))
     }
 
+    pub fn is_proper_list(&self) -> bool {
+        match self {
+            Self::List(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn vector<I>(elements: I) -> Self
     where
         I: IntoIterator,


### PR DESCRIPTION
This adds support for proper procedure definition forms (or at least one variant).
This is the last special form I intend to add this way. The next step is to build a macro expander which will allow us to express derived expressions in terms of macros. This will also greatly simplify the code generator as we only will have to deal with primitive expressions in it. 