### PR TITLE
Expand simple let

### DIFF
--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -122,6 +122,7 @@ impl Expander {
         }
     }
 
+    // TODO: make this behave correctly
     fn create_renamer(&mut self) -> Procedure {
         Procedure::foreign(foreign::Procedure::new(
             "rename",
@@ -130,9 +131,10 @@ impl Expander {
         ))
     }
 
+    // TODO: make this behave correctly
     fn create_comparator(&mut self) -> Procedure {
         Procedure::foreign(foreign::Procedure::new(
-            "rename",
+            "compare",
             |values| binary_procedure(&values).map(|(l, r)| Value::Bool(l == r)),
             Arity::Exactly(2),
         ))

--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -47,8 +47,6 @@ impl Expander {
             Some([operator, operands @ ..]) if operator.is_symbol() => {
                 let denotation = self.denotation_of(operator)?;
                 log::trace!("denotation of {:?} is {:?}", datum, denotation);
-
-                println!("Denotation: {:?} {}", denotation, operator);
                 match denotation {
                     Denotation::Special(special) => match special {
                         Special::Define => self.expand_define(&datum, &operator, &operands),

--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -214,8 +214,8 @@ pub mod tests {
         let expected_datum = parse_datum(rhs);
         let expanded_datum = exp.expand(&actual_datum)?;
 
-        println!("expected: {}", expected_datum);
-        println!("expanded: {}", expanded_datum);
+        //println!("expected: {}", expected_datum);
+        //println!("expanded: {}", expanded_datum);
 
         assert_struct_eq(&expanded_datum, &expected_datum, pedantic);
         Ok(())

--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -68,7 +68,11 @@ impl Expander {
                         Special::Quote => Ok(datum.clone()),
                         _ => self.expand_apply(operator, operands, datum.source_location().clone()),
                     },
-                    Denotation::Macro(transformer) => self.expand_macro(&datum, &transformer),
+                    Denotation::Macro(transformer) => {
+                        let expanded = self.expand_macro(&datum, &transformer)?;
+                        // recursively expand
+                        self.expand_macros(&expanded)
+                    }
                     _ => self.expand_apply(operator, operands, datum.source_location().clone()),
                 }
             }
@@ -210,8 +214,8 @@ pub mod tests {
         let expected_datum = parse_datum(rhs);
         let expanded_datum = exp.expand(&actual_datum)?;
 
-        //println!("expected: {}", expected_datum);
-        //println!("expanded: {}", expanded_datum);
+        println!("expected: {}", expected_datum);
+        println!("expanded: {}", expanded_datum);
 
         assert_struct_eq(&expanded_datum, &expected_datum, pedantic);
         Ok(())

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -1,10 +1,10 @@
-use super::{Error, Expander, Result};
+use super::Expander;
 use crate::compiler::frontend::reader::datum::Datum;
 use crate::compiler::frontend::syntax::environment::Denotation;
 use crate::compiler::frontend::syntax::symbol::Symbol;
 use crate::compiler::frontend::syntax::Transformer;
 use crate::compiler::source::HasSourceLocation;
-use crate::vm::scheme::ffi::{explicit_rename_transformer, ternary_procedure, FunctionResult};
+use crate::vm::scheme::ffi::{explicit_rename_transformer, FunctionResult};
 use crate::vm::value::error;
 use crate::vm::value::procedure::{foreign, Arity, Procedure};
 use crate::vm::value::Value;

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -29,33 +29,9 @@ fn expand_let(args: Vec<Value>) -> FunctionResult<Value> {
         |(datum, _rename, _compare)| match datum.list_slice() {
             // Named let
             // (let f ((v e) ...) b ...)
-            Some([_let, f, bindings, body @ ..]) if bindings.is_proper_list() && f.is_symbol() => {
-                let (lambda, values) =
-                    self::make_lambda(bindings, body, datum.source_location().clone())?;
-
-                // (define f (lambda ...))
-                let definition = Datum::list(
-                    vec![
-                        Datum::forged_symbol("define", datum.source_location().clone()),
-                        f.clone(),
-                        lambda,
-                    ],
-                    datum.source_location().clone(),
-                );
-
-                let mut application = vec![f.clone()];
-                application.extend(values);
-
-                //(begin (define f (lambda ...)) (f initial_arg))
-                let begin = Datum::list(
-                    vec![
-                        Datum::forged_symbol("begin", datum.source_location().clone()),
-                        definition,
-                        Datum::list(application, datum.source_location().clone()),
-                    ],
-                    datum.source_location().clone(),
-                );
-                Ok(Value::syntax(begin))
+            Some([_let, f, bindings, _body @ ..]) if bindings.is_proper_list() && f.is_symbol() => {
+                // named let not yet supported. We first need a working implementation of letrec
+                todo!()
             }
             // let
             // (let ((v e) ...) b ...)
@@ -136,16 +112,6 @@ mod tests {
     #[test]
     fn test_expand_simple_let_empty_bindings() -> Result<()> {
         assert_expands_equal("(let () #t)", "((lambda () #t))", false)?;
-        Ok(())
-    }
-
-    #[test]
-    fn test_named_let() -> Result<()> {
-        assert_expands_equal(
-            "(let lp ((x 0)) (lp (+ x 1)))",
-            "(begin (define lp (lambda (x) (lp (+ x 1)))) (lp 0))",
-            false,
-        )?;
         Ok(())
     }
 }

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -129,6 +129,12 @@ mod tests {
     }
 
     #[test]
+    fn test_expand_simple_let_empty_bindings() -> Result<()> {
+        assert_expands_equal("(let () #t)", "((lambda () #t))", false)?;
+        Ok(())
+    }
+
+    #[test]
     fn test_named_let() -> Result<()> {
         assert_expands_equal(
             "(let lp ((x 0)) (lp (+ x 1)))",

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -66,11 +66,6 @@ fn expand_let(args: Vec<Value>) -> FunctionResult<Value> {
                 let mut application = vec![lambda];
                 application.extend(values);
 
-                println!(
-                    "Expanding to: {}",
-                    Datum::list(application.clone(), datum.source_location().clone())
-                );
-
                 Ok(Value::syntax(Datum::list(
                     application,
                     datum.source_location().clone(),

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -1,0 +1,82 @@
+use super::{Error, Expander, Result};
+use crate::compiler::frontend::reader::datum::Datum;
+use crate::compiler::frontend::syntax::environment::Denotation;
+use crate::compiler::frontend::syntax::symbol::Symbol;
+use crate::compiler::frontend::syntax::Transformer;
+use crate::compiler::source::HasSourceLocation;
+use crate::vm::scheme::ffi::{explicit_rename_transformer, ternary_procedure, FunctionResult};
+use crate::vm::value::error;
+use crate::vm::value::procedure::{foreign, Arity, Procedure};
+use crate::vm::value::Value;
+
+pub fn register_macros(expander: &mut Expander) {
+    expander.expansion_env.extend(
+        Symbol::forged("let"),
+        Denotation::Macro(Transformer::ExplicitRenaming(self::make_let_expander())),
+    );
+}
+
+fn make_let_expander() -> Procedure {
+    Procedure::foreign(foreign::Procedure::new(
+        "expand_let",
+        self::expand_let,
+        Arity::Exactly(3),
+    ))
+}
+
+fn expand_let(args: Vec<Value>) -> FunctionResult<Value> {
+    explicit_rename_transformer(&args).and_then({
+        |(datum, _rename, _compare)| match datum.list_slice() {
+            // (let ((v e) ...) b ...)
+            Some([_let, bindings, body @ ..]) => match bindings.list_slice() {
+                Some([bindings @ ..]) => {
+                    let mut identifiers = vec![];
+                    let mut values = vec![];
+
+                    for binding in bindings {
+                        match binding.list_slice() {
+                            Some([id, value]) => {
+                                identifiers.push(id.clone());
+                                values.push(value.clone());
+                            }
+                            _ => return Err(error::syntax_error("invalid binding form")),
+                        }
+                    }
+
+                    // now we build the corresponding lambda expression
+                    let mut lambda = vec![
+                        Datum::forged_symbol("lambda", datum.source_location().clone()),
+                        Datum::list(identifiers, datum.source_location().clone()),
+                    ];
+                    lambda.extend_from_slice(body);
+
+                    let mut application =
+                        vec![Datum::list(lambda, datum.source_location().clone())];
+                    application.extend(values);
+
+                    Ok(Value::syntax(Datum::list(
+                        application,
+                        datum.source_location().clone(),
+                    )))
+                }
+                _ => Err(error::syntax_error("Invalid let form")),
+            },
+            _ => Err(error::argument_error(
+                Value::Syntax(datum.clone()),
+                "expected syntax object to be proper list",
+            )),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::*;
+    use super::super::Result;
+
+    #[test]
+    fn test_expand_simple_let() -> Result<()> {
+        assert_expands_equal("(let ((x #t)) x)", "((lambda (x) x) #t)", false)?;
+        Ok(())
+    }
+}

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -124,6 +124,16 @@ mod tests {
     }
 
     #[test]
+    fn test_expand_nested_let() -> Result<()> {
+        assert_expands_equal(
+            "(let ((x #t)) (let ((y x)) y))",
+            "((lambda (x) ((lambda (y) y) x)) #t)",
+            false,
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn test_expand_simple_let_empty_bindings() -> Result<()> {
         assert_expands_equal("(let () #t)", "((lambda () #t))", false)?;
         Ok(())

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -3,7 +3,7 @@ use crate::compiler::frontend::reader::datum::Datum;
 use crate::compiler::frontend::syntax::environment::Denotation;
 use crate::compiler::frontend::syntax::symbol::Symbol;
 use crate::compiler::frontend::syntax::Transformer;
-use crate::compiler::source::HasSourceLocation;
+use crate::compiler::source::{HasSourceLocation, Location};
 use crate::vm::scheme::ffi::{explicit_rename_transformer, FunctionResult};
 use crate::vm::value::error;
 use crate::vm::value::procedure::{foreign, Arity, Procedure};
@@ -27,46 +27,94 @@ fn make_let_expander() -> Procedure {
 fn expand_let(args: Vec<Value>) -> FunctionResult<Value> {
     explicit_rename_transformer(&args).and_then({
         |(datum, _rename, _compare)| match datum.list_slice() {
+            // Named let
+            // (let f ((v e) ...) b ...)
+            Some([_let, f, bindings, body @ ..]) if bindings.is_proper_list() && f.is_symbol() => {
+                let (lambda, values) =
+                    self::make_lambda(bindings, body, datum.source_location().clone())?;
+
+                // (define f (lambda ...))
+                let definition = Datum::list(
+                    vec![
+                        Datum::forged_symbol("define", datum.source_location().clone()),
+                        f.clone(),
+                        lambda,
+                    ],
+                    datum.source_location().clone(),
+                );
+
+                let mut application = vec![f.clone()];
+                application.extend(values);
+
+                //(begin (define f (lambda ...)) (f initial_arg))
+                let begin = Datum::list(
+                    vec![
+                        Datum::forged_symbol("begin", datum.source_location().clone()),
+                        definition,
+                        Datum::list(application, datum.source_location().clone()),
+                    ],
+                    datum.source_location().clone(),
+                );
+                Ok(Value::syntax(begin))
+            }
+            // let
             // (let ((v e) ...) b ...)
-            Some([_let, bindings, body @ ..]) => match bindings.list_slice() {
-                Some([bindings @ ..]) => {
-                    let mut identifiers = vec![];
-                    let mut values = vec![];
+            Some([_let, bindings, body @ ..]) => {
+                let (lambda, values) =
+                    self::make_lambda(bindings, body, datum.source_location().clone())?;
 
-                    for binding in bindings {
-                        match binding.list_slice() {
-                            Some([id, value]) => {
-                                identifiers.push(id.clone());
-                                values.push(value.clone());
-                            }
-                            _ => return Err(error::syntax_error("invalid binding form")),
-                        }
-                    }
+                let mut application = vec![lambda];
+                application.extend(values);
 
-                    // now we build the corresponding lambda expression
-                    let mut lambda = vec![
-                        Datum::forged_symbol("lambda", datum.source_location().clone()),
-                        Datum::list(identifiers, datum.source_location().clone()),
-                    ];
-                    lambda.extend_from_slice(body);
+                println!(
+                    "Expanding to: {}",
+                    Datum::list(application.clone(), datum.source_location().clone())
+                );
 
-                    let mut application =
-                        vec![Datum::list(lambda, datum.source_location().clone())];
-                    application.extend(values);
+                Ok(Value::syntax(Datum::list(
+                    application,
+                    datum.source_location().clone(),
+                )))
+            }
 
-                    Ok(Value::syntax(Datum::list(
-                        application,
-                        datum.source_location().clone(),
-                    )))
-                }
-                _ => Err(error::syntax_error("Invalid let form")),
-            },
             _ => Err(error::argument_error(
                 Value::Syntax(datum.clone()),
                 "expected syntax object to be proper list",
             )),
         }
     })
+}
+
+pub fn make_lambda(
+    bindings: &Datum,
+    body: &[Datum],
+    loc: Location,
+) -> FunctionResult<(Datum, Vec<Datum>)> {
+    match bindings.list_slice() {
+        Some([bindings @ ..]) => {
+            let mut identifiers = vec![];
+            let mut values = vec![];
+
+            for binding in bindings {
+                match binding.list_slice() {
+                    Some([id, value]) => {
+                        identifiers.push(id.clone());
+                        values.push(value.clone());
+                    }
+                    _ => return Err(error::syntax_error("invalid binding form")),
+                }
+            }
+
+            // now we build the corresponding lambda expression
+            let mut lambda = vec![
+                Datum::forged_symbol("lambda", loc.clone()),
+                Datum::list(identifiers, loc.clone()),
+            ];
+            lambda.extend_from_slice(body);
+            Ok((Datum::list(lambda, loc.clone()), values))
+        }
+        _ => Err(error::syntax_error("Invalid let form")),
+    }
 }
 
 #[cfg(test)]
@@ -77,6 +125,16 @@ mod tests {
     #[test]
     fn test_expand_simple_let() -> Result<()> {
         assert_expands_equal("(let ((x #t)) x)", "((lambda (x) x) #t)", false)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_named_let() -> Result<()> {
+        assert_expands_equal(
+            "(let lp ((x 0)) (lp (+ x 1)))",
+            "(begin (define lp (lambda (x) (lp (+ x 1)))) (lp 0))",
+            false,
+        )?;
         Ok(())
     }
 }

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -35,7 +35,7 @@ fn expand_let(args: Vec<Value>) -> FunctionResult<Value> {
             }
             // let
             // (let ((v e) ...) b ...)
-            Some([_let, bindings, body @ ..]) => {
+            Some([_let, bindings, body @ ..]) if body.len() >= 1 => {
                 let (lambda, values) =
                     self::make_lambda(bindings, body, datum.source_location().clone())?;
 
@@ -47,10 +47,9 @@ fn expand_let(args: Vec<Value>) -> FunctionResult<Value> {
                     datum.source_location().clone(),
                 )))
             }
-
             _ => Err(error::argument_error(
                 Value::Syntax(datum.clone()),
-                "expected syntax object to be proper list",
+                "expansion of let failed. Incorrect form given",
             )),
         }
     })

--- a/src/compiler/frontend/reader/datum.rs
+++ b/src/compiler/frontend/reader/datum.rs
@@ -119,6 +119,7 @@ impl Datum {
     /// for runtime values as it uses for s-expressions. This converts between the two worlds.
     pub fn from_value(v: &Value, location: Location) -> Option<Self> {
         match v {
+            Value::Syntax(datum) => Some(datum.clone()),
             Value::Char(c) => Some(Self::character(c.clone(), location)),
             Value::Symbol(sym) => Some(Self::forged_symbol(sym.as_str(), location)),
             Value::InternedString(s) => Some(Self::string(s.as_str(), location)),

--- a/src/vm/error/reporting.rs
+++ b/src/vm/error/reporting.rs
@@ -52,6 +52,9 @@ impl<'a> ErrorReporter<'a> {
             RuntimeError::UndefinedVariable(s) => {
                 format!("UndefinedVariable: Variable `{}` is undefined", s.as_str())
             }
+            RuntimeError::SyntaxError(msg) => {
+                format!("Error during macro expansion: {}", msg)
+            }
         }
     }
 }

--- a/src/vm/instance.rs
+++ b/src/vm/instance.rs
@@ -667,7 +667,7 @@ impl<'a> Instance<'a> {
                 Ok(())
             }
             Err(e) => {
-                println!("Error in foreign function: {}", proc.name.clone());
+                println!("Error in foreign function: {} {:?}", proc.name.clone(), e);
                 self.runtime_error(e, Some(proc.name.clone()))
             }
         }
@@ -942,15 +942,19 @@ impl<'a> Instance<'a> {
 
     // TODO: add a representation for stack trace and add it to the error
     fn runtime_error<T>(&self, e: error::RuntimeError, context: Option<String>) -> Result<T> {
-        let result = Err(Error::RuntimeError(
-            e,
-            self.active_frame()
-                .line_number_for_current_instruction()
-                .unwrap_or(0),
-            StackTrace::from(&self.call_stack),
-            context,
-        ));
-        result
+        if self.has_active_frame() {
+            let result = Err(Error::RuntimeError(
+                e,
+                self.active_frame()
+                    .line_number_for_current_instruction()
+                    .unwrap_or(0),
+                StackTrace::from(&self.call_stack),
+                context,
+            ));
+            result
+        } else {
+            Err(Error::RuntimeError(e, 0, StackTrace::empty(), context))
+        }
     }
 
     // Debug the VM

--- a/src/vm/scheme/ffi.rs
+++ b/src/vm/scheme/ffi.rs
@@ -1,3 +1,4 @@
+use crate::compiler::frontend::reader::datum::Datum;
 use crate::vm::value::Value;
 use crate::vm::value::{error, procedure::Arity};
 use thiserror::Error;
@@ -24,14 +25,34 @@ impl ToScheme for bool {
 }
 
 // Helpers
-pub fn binary_procedure<'a>(args: &'a Vec<Value>) -> FunctionResult<(&'a Value, &'a Value)> {
+pub fn explicit_rename_transformer(args: &Vec<Value>) -> FunctionResult<(&Datum, &Value, &Value)> {
+    match &args[..] {
+        [first, second, third] => match first {
+            Value::Syntax(datum) => Ok((datum, second, third)),
+            _ => Err(error::argument_error(
+                first.clone(),
+                "expected syntax object",
+            )),
+        },
+        _ => Err(error::arity_mismatch(Arity::Exactly(3), args.len())),
+    }
+}
+
+pub fn ternary_procedure(args: &Vec<Value>) -> FunctionResult<(&Value, &Value, &Value)> {
+    match &args[..] {
+        [first, second, third] => Ok((first, second, third)),
+        _ => Err(error::arity_mismatch(Arity::Exactly(3), args.len())),
+    }
+}
+
+pub fn binary_procedure(args: &Vec<Value>) -> FunctionResult<(&Value, &Value)> {
     match &args[..] {
         [first, second] => Ok((first, second)),
         _ => Err(error::arity_mismatch(Arity::Exactly(2), args.len())),
     }
 }
 
-pub fn unary_procedure<'a>(args: &'a Vec<Value>) -> FunctionResult<&'a Value> {
+pub fn unary_procedure(args: &Vec<Value>) -> FunctionResult<&Value> {
     match &args[..] {
         [first] => Ok(first),
         _ => Err(error::arity_mismatch(Arity::Exactly(1), args.len())),

--- a/src/vm/scheme/writer.rs
+++ b/src/vm/scheme/writer.rs
@@ -34,6 +34,7 @@ impl Writer {
 
     fn write_impl(&self, v: &Value, values: &Factory, quote: bool) -> String {
         match v {
+            Value::Syntax(datum) => self.write_string(format!("#<syntax {}>", datum).as_str()),
             Value::Bool(true) => "#t".to_string(),
             Value::Bool(false) => "#f".to_string(),
             Value::Symbol(s) => self.write_symbol(s.as_str(), quote),

--- a/src/vm/stack_trace.rs
+++ b/src/vm/stack_trace.rs
@@ -12,6 +12,10 @@ pub struct StackTrace {
 }
 
 impl StackTrace {
+    pub fn empty() -> Self {
+        Self { frames: vec![] }
+    }
+
     pub fn new(call_stack: &CallStack) -> Self {
         let mut info = vec![];
 

--- a/src/vm/value/error.rs
+++ b/src/vm/value/error.rs
@@ -14,6 +14,12 @@ pub enum RuntimeError {
     NoncallableError(Value),
     #[error("ArithmeticError: `{0}`")]
     ArithmeticError(String),
+    #[error("SyntaxError")]
+    SyntaxError(String),
+}
+
+pub fn syntax_error<T: Into<String>>(msg: T) -> RuntimeError {
+    RuntimeError::SyntaxError(msg.into())
 }
 
 pub fn arithmetic_error<T: Into<String>>(msg: T) -> RuntimeError {

--- a/src/vm/value/procedure.rs
+++ b/src/vm/value/procedure.rs
@@ -12,7 +12,7 @@ pub enum Arity {
 }
 
 pub trait HasArity {
-    fn arity<'a>(&'a self) -> &'a Arity;
+    fn arity(&self) -> &Arity;
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/vm/value/procedure/foreign.rs
+++ b/src/vm/value/procedure/foreign.rs
@@ -30,13 +30,13 @@ impl Procedure {
 }
 
 impl HasArity for Procedure {
-    fn arity<'a>(&'a self) -> &'a Arity {
+    fn arity(&self) -> &Arity {
         &self.arity
     }
 }
 
 impl HasArity for std::rc::Rc<Procedure> {
-    fn arity<'a>(&'a self) -> &'a Arity {
+    fn arity(&self) -> &Arity {
         &self.arity
     }
 }

--- a/tests/vm_tests.rs
+++ b/tests/vm_tests.rs
@@ -314,11 +314,11 @@ fn test_vm_smoke_test() {
 
         (define (fib n) (if (<= n 2) 1 (+ (fib (- n 1)) (fib (- n 2)))))
 
-        (fib 10)
+        (fib 20)
         "#,
     )
     .unwrap();
-    assert_eq!(result, vm.values.real(55));
+    assert_eq!(result, vm.values.real(6765));
 }
 
 #[test]


### PR DESCRIPTION
Add expansion for `let` syntax to the expander. To make this work I started to add the macro expansion facility.
It uses the VM to expand the supplied syntax and thus forms the skeleton for user-defined syntax.
However it currently doesn't take care of hygiene (not required so far) and is probably not supporting all cases yet.

It adds an expander for a simple let, which expands into the corresponding lambda expressions.
At a later point I'll think about whether it's preferable to compile let expressions differently, which would required to preserve them and parse them into an expression. 

## Important
This doesn't implement named let as that requires a proper implementation of letrec first