### PR TITLE
low level macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rug = "1.12"
 az = "1.1.1"
 
 # compiler / interpreter
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"
 rustyline = "8.0.0"
 hashbrown = "0.11"
 fasthash = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,6 @@ version = "0.1.0"
 authors = ["certainty <david.krentzlin@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-# [[bench]]
-# name = "compiler"
-# harness = false
-
-# [[bench]]
-# name="vm"
-# harness = false
-
-
 [lib]
 name="braces"
 path="src/lib.rs"

--- a/src/bin/bracesi.rs
+++ b/src/bin/bracesi.rs
@@ -2,16 +2,15 @@ extern crate clap;
 use braces::cmd::compile;
 use braces::cmd::repl;
 use braces::cmd::run;
-use clap::{AppSettings, Clap};
+use clap::Parser;
 
-#[derive(Clap)]
-#[clap(setting = AppSettings::ColoredHelp)]
+#[derive(Parser)]
 struct Opts {
     #[clap(subcommand)]
     subcmd: SubCommand,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 enum SubCommand {
     #[clap(version = "0.1", author = "David K.")]
     Repl(repl::Opts),

--- a/src/bin/bracesi.rs
+++ b/src/bin/bracesi.rs
@@ -1,3 +1,4 @@
+extern crate clap;
 use braces::cmd::compile;
 use braces::cmd::repl;
 use braces::cmd::run;

--- a/src/cmd/compile.rs
+++ b/src/cmd/compile.rs
@@ -1,6 +1,6 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap)]
+#[derive(Parser)]
 pub struct Opts {}
 
 pub fn execute(_opts: &Opts) -> anyhow::Result<()> {

--- a/src/cmd/repl.rs
+++ b/src/cmd/repl.rs
@@ -1,8 +1,8 @@
 use crate::repl;
 use crate::vm::VM;
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(version = "0.1", author = "David K.", about = "Start the REPL")]
 pub struct Opts {}
 

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,10 +1,10 @@
 use crate::compiler::source::FileSource;
 use crate::compiler::Compiler;
 use crate::vm::VM;
-use clap::Clap;
+use clap::Parser;
 use std::path::PathBuf;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(
     version = "0.1",
     author = "David K.",

--- a/src/compiler/backend.rs
+++ b/src/compiler/backend.rs
@@ -4,7 +4,10 @@ pub mod variables;
 use super::representation::CoreAST;
 
 use super::CompilationUnit;
+use crate::compiler::backend::code_generator::Target;
+use crate::compiler::frontend::parser::lambda::LambdaExpression;
 use crate::compiler::source::Registry;
+use crate::vm::value;
 use code_generator::CodeGenerator;
 
 #[derive(Debug)]
@@ -23,5 +26,23 @@ impl Backend {
     ) -> std::result::Result<CompilationUnit, error::Error> {
         let unit = CodeGenerator::generate(registry, ast)?;
         Ok(unit)
+    }
+
+    /// Generate a native procedure from a lambda expression
+    /// This is used by the macro expander to compiler transformer procedures
+    pub fn generate_lambda(
+        &self,
+        lambda_expression: &LambdaExpression,
+    ) -> std::result::Result<value::procedure::native::Procedure, error::Error> {
+        let registry = Registry::new();
+        let compiled = CodeGenerator::generate_procedure(
+            &registry,
+            None,
+            Target::Procedure(None),
+            &lambda_expression.body,
+            &lambda_expression.formals,
+        )?;
+
+        Ok(compiled)
     }
 }

--- a/src/compiler/core_compiler.rs
+++ b/src/compiler/core_compiler.rs
@@ -1,7 +1,9 @@
 use crate::compiler;
+use crate::compiler::frontend::parser::lambda::LambdaExpression;
 use crate::compiler::representation::CoreAST;
 use crate::compiler::source::Registry;
 use crate::compiler::{backend, frontend, CompilationUnit};
+use crate::vm::value;
 
 /// The `CoreCompiler` is used to compile the `CoreAST`
 /// down to the byte code representation.
@@ -31,5 +33,13 @@ impl CoreCompiler {
         let unit = self.backend.pass(&ast, &registry)?;
         log::trace!("backend pass done: {:#?}", unit);
         Ok(unit)
+    }
+
+    pub fn compile_lambda(
+        &mut self,
+        lambda: &LambdaExpression,
+    ) -> compiler::Result<value::procedure::Procedure> {
+        let proc = self.backend.generate_lambda(&lambda)?;
+        Ok(value::procedure::Procedure::native(proc))
     }
 }

--- a/src/compiler/error/reporting.rs
+++ b/src/compiler/error/reporting.rs
@@ -105,6 +105,7 @@ impl<'a> ErrorReporter<'a> {
                     .with_labels(labels)
             }
             Bug(message) => Diagnostic::bug().with_message(message),
+            NotImplemented(message) => Diagnostic::error().with_code("E999").with_message(message),
         }
     }
 

--- a/src/compiler/frontend/error.rs
+++ b/src/compiler/frontend/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     IncompleteInput(String, Option<Origin>),
     #[error("Bug")]
     Bug(String),
+    #[error("Not yet implemented")]
+    NotImplemented(String),
     #[error("ReadError")]
     ReadError(String, Detail, Vec<Detail>),
     #[error("ReadError")]

--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -216,7 +216,7 @@ impl Expander {
     fn create_renamer(&mut self) -> Procedure {
         Procedure::foreign(foreign::Procedure::new(
             "rename",
-            |values| unary_procedure(&values).map(|v| Access::ByVal(v.clone())),
+            |_ctx, values| unary_procedure(&values).map(|v| Access::ByVal(v.clone())),
             Arity::Exactly(1),
         ))
     }
@@ -225,7 +225,9 @@ impl Expander {
     fn create_comparator(&mut self) -> Procedure {
         Procedure::foreign(foreign::Procedure::new(
             "compare",
-            |values| binary_procedure(&values).map(|(l, r)| Access::from(Value::Bool(l == r))),
+            |_ctx, values| {
+                binary_procedure(&values).map(|(l, r)| Access::from(Value::Bool(l == r)))
+            },
             Arity::Exactly(2),
         ))
     }
@@ -327,8 +329,8 @@ pub mod tests {
         let expected_datum = parse_datum(rhs);
         let expanded_datum = exp.expand(&actual_datum)?.unwrap();
 
-        //println!("expected: {}", expected_datum);
-        //println!("expanded: {}", expanded_datum);
+        println!("expected: {}", expected_datum);
+        println!("expanded: {}", expanded_datum);
 
         assert_struct_eq(&expanded_datum, &expected_datum, pedantic);
         Ok(())

--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -48,6 +48,7 @@ impl Expander {
         match datum.list_slice() {
             Some([operator, operands @ ..]) if operator.is_symbol() => {
                 let denotation = self.denotation_of(operator)?;
+                //println!("Denotation of {} is {:?}", operator, denotation);
                 log::trace!("denotation of {:?} is {:?}", datum, denotation);
                 match denotation {
                     Denotation::Special(special) => match special {
@@ -172,6 +173,7 @@ impl Expander {
                         },
                         "lowlevel-macro-transformer" => {
                             let transformer = syntax::Transformer::LowLevel(self.compile_lambda(&procedure)?);
+                            println!("Extending env with macro: {}", sym.as_str());
                             self.expansion_env.extend(sym.clone(), Denotation::Macro(transformer));
                             Ok(())
                         },

--- a/src/compiler/frontend/expander.rs
+++ b/src/compiler/frontend/expander.rs
@@ -346,8 +346,8 @@ pub mod tests {
         let expected_datum = parse_datum(rhs);
         let expanded_datum = exp.expand(&actual_datum)?.unwrap();
 
-        println!("expected: {}", expected_datum);
-        println!("expanded: {}", expanded_datum);
+        //println!("expected: {}", expected_datum);
+        //println!("expanded: {}", expanded_datum);
 
         assert_struct_eq(&expanded_datum, &expected_datum, pedantic);
         Ok(())

--- a/src/compiler/frontend/expander/define.rs
+++ b/src/compiler/frontend/expander/define.rs
@@ -20,7 +20,9 @@ impl Expander {
                             exprs,
                             datum.source_location().clone(),
                         );
-                        let expanded_lambda = self.expand_macros(&lambda)?;
+                        let expanded_lambda = self
+                            .expand_macros(&lambda)?
+                            .expect("lambda body must expand correctly");
 
                         Ok(Datum::list(
                             vec![operator.clone(), identifier.clone(), expanded_lambda],
@@ -46,7 +48,7 @@ impl Expander {
                                 exprs,
                                 datum.source_location().clone()
                             );
-                            let expanded_lambda = self.expand_macros(&lambda)?;
+                            let expanded_lambda = self.expand_macros(&lambda)?.expect("expected lambda body to expand correctly");
 
                             Ok(Datum::list(vec![operator.clone(), identifier.clone(), expanded_lambda], datum.source_location().clone()))
                         }
@@ -61,7 +63,7 @@ impl Expander {
                                 exprs,
                                 datum.source_location().clone(),
                             );
-                            let expanded_lambda = self.expand_macros(&lambda)?;
+                            let expanded_lambda = self.expand_macros(&lambda)?.expect("expected lambda body to expand correctly");
 
                             Ok(Datum::list(vec![operator.clone(), identifier.clone(), expanded_lambda], datum.source_location().clone()))
                         }
@@ -77,8 +79,8 @@ impl Expander {
             }
             //(define <id> <expr>)
             [location, expr] => {
-                let expanded_location = self.expand_macros(location)?;
-                let expanded_expr = self.expand_macros(expr)?;
+                let expanded_location = self.expand_macros(location)?.expect("expected location");
+                let expanded_expr = self.expand_macros(expr)?.expect("expected expression");
                 Ok(Datum::list(
                     vec![
                         operator.clone(),

--- a/src/compiler/frontend/expander/lambda.rs
+++ b/src/compiler/frontend/expander/lambda.rs
@@ -15,13 +15,13 @@ impl Expander {
             [formals, body @ ..] => {
                 match self.parser.parse_formals(&formals) {
                     Ok(parsed_formals) => {
-                        self.expansion_env.push_scope();
+                        self.push_scope();
                         for identifier in parsed_formals.identifiers() {
                             let sym = identifier.symbol().clone();
-                            self.expansion_env.extend(sym.clone(), Denotation::Id);
+                            self.extend_scope(sym.clone(), Denotation::Id);
                         }
                         let expanded_body = self.expand_all(body)?;
-                        self.expansion_env.pop_scope();
+                        self.pop_scope();
 
                         Ok(self.build_lambda(
                             &formals,

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -11,7 +11,7 @@ use crate::vm::value::procedure::{foreign, Arity, Procedure};
 use crate::vm::value::Value;
 
 pub fn register_macros(expander: &mut Expander) {
-    expander.expansion_env.extend(
+    expander.extend_scope(
         Symbol::forged("let"),
         Denotation::Macro(Transformer::ExplicitRenaming(self::make_let_expander())),
     );

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -27,7 +27,7 @@ fn make_let_expander() -> Procedure {
 
 fn expand_let(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     explicit_rename_transformer(&args).and_then({
-        |(datum, _rename, _compare)| match datum.list_slice() {
+        |(form, _rename, _compare)| match form.list_slice() {
             // Named let
             // (let f ((v e) ...) b ...)
             Some([_let, f, bindings, _body @ ..]) if bindings.is_proper_list() && f.is_symbol() => {
@@ -46,7 +46,7 @@ fn expand_let(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<V
                 Ok(Value::syntax(Datum::list(application, datum.source_location().clone())).into())
             }
             _ => Err(error::argument_error(
-                Value::Syntax(datum.clone()),
+                form.clone(),
                 "expansion of let failed. Incorrect form given",
             )),
         }

--- a/src/compiler/frontend/expander/letexp.rs
+++ b/src/compiler/frontend/expander/letexp.rs
@@ -4,7 +4,7 @@ use crate::compiler::frontend::syntax::environment::Denotation;
 use crate::compiler::frontend::syntax::symbol::Symbol;
 use crate::compiler::frontend::syntax::Transformer;
 use crate::compiler::source::{HasSourceLocation, Location};
-use crate::vm::scheme::ffi::{explicit_rename_transformer, FunctionResult};
+use crate::vm::scheme::ffi::{explicit_rename_transformer, FunctionResult, VmContext};
 use crate::vm::value::access::Access;
 use crate::vm::value::error;
 use crate::vm::value::procedure::{foreign, Arity, Procedure};
@@ -25,7 +25,7 @@ fn make_let_expander() -> Procedure {
     ))
 }
 
-fn expand_let(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+fn expand_let(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     explicit_rename_transformer(&args).and_then({
         |(datum, _rename, _compare)| match datum.list_slice() {
             // Named let

--- a/src/compiler/frontend/expander/quotation.rs
+++ b/src/compiler/frontend/expander/quotation.rs
@@ -135,11 +135,11 @@ impl Expander {
                         "quasi-quote can't be nested",
                         &datum,
                     )),
-                    Denotation::Special(Special::Unquote) => {
-                        Ok(QuoteJoin::Cons(self.expand(operand)?))
-                    }
+                    Denotation::Special(Special::Unquote) => Ok(QuoteJoin::Cons(
+                        self.expand(operand)?.expect("non-empty expansion"),
+                    )),
                     Denotation::Special(Special::UnquoteSplicing) => {
-                        let expanded = self.expand(operand)?;
+                        let expanded = self.expand(operand)?.expect("non-empty expansion");
                         Ok(QuoteJoin::Append(expanded))
                     }
                     _ => Ok(QuoteJoin::Cons(datum.clone())),

--- a/src/compiler/frontend/expander/quotation.rs
+++ b/src/compiler/frontend/expander/quotation.rs
@@ -187,4 +187,13 @@ mod tests {
         assert!(expand_form("`(1 2 `3)").is_err(), "expected error");
         Ok(())
     }
+
+    #[test]
+    fn quasi_quote_edge_cases() -> Result<()> {
+        assert_expands_equal(
+            "`(begin (define ,x #t))",
+            "(cons 'begin (cons 'define (cons x (cons #t '()))))",
+            false,
+        )
+    }
 }

--- a/src/compiler/frontend/expander/quotation.rs
+++ b/src/compiler/frontend/expander/quotation.rs
@@ -188,7 +188,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
+    // NOT sure this is an edge case
+    //#[test]
     fn quasi_quote_edge_cases() -> Result<()> {
         assert_expands_equal(
             "`(begin (define ,x #t))",

--- a/src/compiler/frontend/reader.rs
+++ b/src/compiler/frontend/reader.rs
@@ -31,6 +31,10 @@ pub mod tests {
     use super::Reader;
 
     pub fn parse_datum(inp: &str) -> Datum {
+        parse_datum_all(inp)[0].clone()
+    }
+
+    pub fn parse_datum_all(inp: &str) -> Vec<Datum> {
         let mut registry = Registry::new();
         let source = registry
             .add(&mut BufferSource::new(inp, "datum-parser-test"))
@@ -38,7 +42,7 @@ pub mod tests {
         let reader = Reader::new();
         let datum = reader.parse(&source).unwrap();
 
-        datum.to_vec()[0].clone()
+        datum.to_vec().clone()
     }
 
     // test helpers to use in the datum parser

--- a/src/compiler/frontend/reader/datum.rs
+++ b/src/compiler/frontend/reader/datum.rs
@@ -121,6 +121,7 @@ impl Datum {
         match v {
             Value::Syntax(datum) => Some(datum.clone()),
             Value::Char(c) => Some(Self::character(c.clone(), location)),
+            Value::UninternedSymbol(s) => Some(Self::Symbol(s.clone(), location)),
             Value::Symbol(sym) => Some(Self::forged_symbol(sym.as_str(), location)),
             Value::String(s) => Some(Self::string(s.as_ref(), location)),
             Value::Number(n) => Some(Self::number(n.clone(), location)),

--- a/src/compiler/frontend/syntax.rs
+++ b/src/compiler/frontend/syntax.rs
@@ -6,5 +6,6 @@ pub mod symbol;
 
 #[derive(Debug, Clone)]
 pub enum Transformer {
+    LowLevel(procedure::Procedure),
     ExplicitRenaming(procedure::Procedure),
 }

--- a/src/compiler/frontend/syntax.rs
+++ b/src/compiler/frontend/syntax.rs
@@ -1,11 +1,8 @@
 use crate::vm::value::procedure;
-
 pub mod environment;
-
 pub mod symbol;
 
 #[derive(Debug, Clone)]
 pub enum Transformer {
-    LowLevel(procedure::Procedure),
     ExplicitRenaming(procedure::Procedure),
 }

--- a/src/compiler/frontend/syntax.rs
+++ b/src/compiler/frontend/syntax.rs
@@ -5,4 +5,5 @@ pub mod symbol;
 #[derive(Debug, Clone)]
 pub enum Transformer {
     ExplicitRenaming(procedure::Procedure),
+    LowLevel(procedure::Procedure),
 }

--- a/src/compiler/frontend/syntax/environment.rs
+++ b/src/compiler/frontend/syntax/environment.rs
@@ -56,8 +56,6 @@ pub enum Special {
     LetrecSyntax,
 }
 
-type Renaming = (Symbol, Symbol); // from, to
-
 #[derive(Debug, Clone)]
 pub struct SyntaxEnvironment {
     scopes: Vec<FxHashMap<Symbol, Denotation>>,
@@ -174,29 +172,14 @@ impl SyntaxEnvironment {
         Denotation::Id
     }
 
-    // Given a syntactic environment env to be extended, an alist returned
-    // by rename-vars, and a syntactic environment env2, extends env by
-    // binding the fresh identifiers to the denotations of the original
-    // identifiers in env2.
-    pub fn alias(&mut self, source: SyntaxEnvironment, renamed_ids: Vec<Renaming>) {
-        for (old, new) in renamed_ids {
-            let denotation = source.get(&old);
-            self.extend(new, denotation.clone());
-        }
-    }
-
-    // Given a syntactic environment and an alist returned by rename-vars,
-    // extends the environment by binding the old identifiers to the fresh
-    // identifiers.
-    pub fn rename(&mut self, renamed_ids: Vec<Renaming>) {
-        for (old, new) in renamed_ids {
-            let denotation = Denotation::Id;
-            self.extend(old, denotation.clone());
-            self.extend(new, denotation);
-        }
+    /// Creates an alias, that binds the symbol to the denotation of the other symbol
+    pub fn alias(&mut self, id: Symbol, alias: Symbol) {
+        let denotation = self.get(&id);
+        self.extend(alias, denotation.clone())
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct Renamer {
     counter: u64,
 }
@@ -206,8 +189,8 @@ impl Renamer {
         Renamer { counter: 0 }
     }
 
-    pub fn rename(&mut self, id: Symbol) -> Symbol {
+    pub fn rename(&mut self, id: &Symbol) -> Symbol {
         self.counter += 1;
-        Symbol::renamed(id.string().clone(), self.counter)
+        Symbol::renamed(id.clone().string(), self.counter)
     }
 }

--- a/src/compiler/source/location.rs
+++ b/src/compiler/source/location.rs
@@ -15,6 +15,10 @@ pub struct Location {
 }
 
 impl Location {
+    pub fn for_syntax_transformer() -> Self {
+        Self::new(SourceId::synthetic(), 0..0)
+    }
+
     pub fn new<S: Into<Span>, Id: Into<SourceId>>(id: Id, span: S) -> Self {
         Self {
             id: id.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate im_rc;
 extern crate thiserror;
 
+extern crate clap;
 extern crate lazy_static;
 extern crate nom;
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -21,6 +21,7 @@ use crate::vm::value::procedure::Procedure;
 
 use self::value::procedure::foreign;
 use self::value::procedure::native;
+use crate::vm::scheme::ffi::VmContext;
 
 pub mod byte_code;
 pub mod debug;
@@ -38,6 +39,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub struct VM {
+    context: VmContext,
     stack_size: usize,
     pub values: value::Factory,
     pub top_level: TopLevel,
@@ -49,6 +51,7 @@ impl VM {
     pub fn new(stack_size: usize) -> VM {
         VM {
             stack_size,
+            context: VmContext::new(),
             values: value::Factory::default(),
             top_level: TopLevel::new(),
             writer: Writer::new(),
@@ -90,6 +93,7 @@ impl VM {
         Instance::interpret(
             unit.closure,
             self.stack_size,
+            &mut self.context,
             &mut self.top_level,
             &mut self.values,
             debug_mode,
@@ -109,6 +113,7 @@ impl VM {
                 procedure,
                 &Value::syntax(datum.clone()),
                 arguments,
+                &mut self.context,
                 &mut self.top_level,
                 &mut self.values,
             )?,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -11,7 +11,6 @@ pub use settings::{Setting, Settings};
 use value::Value;
 
 use crate::compiler::frontend::reader::datum::Datum;
-use crate::compiler::frontend::syntax::environment::SyntaxEnvironment;
 use crate::compiler::source::Location;
 use crate::compiler::CompilationUnit;
 use crate::compiler::Compiler;
@@ -105,7 +104,6 @@ impl VM {
         procedure: Procedure,
         datum: &Datum,
         arguments: &[Value],
-        _env: SyntaxEnvironment,
         location: Location,
     ) -> Result<Datum> {
         let form_value = Value::from_datum(&datum, &mut self.values);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -57,7 +57,9 @@ impl VM {
     }
 
     pub fn for_expansion() -> VM {
-        Self::new(255)
+        let mut vm = Self::new(255);
+        core::register(&mut vm);
+        vm
     }
 
     pub fn binding_names(&self) -> Vec<String> {
@@ -98,8 +100,7 @@ impl VM {
         &mut self,
         procedure: Procedure,
         datum: &Datum,
-        rename: Procedure,
-        compare: Procedure,
+        arguments: &[Value],
         _env: SyntaxEnvironment,
         location: Location,
     ) -> Result<Datum> {
@@ -107,8 +108,7 @@ impl VM {
             &Instance::interpret_expander(
                 procedure,
                 &Value::syntax(datum.clone()),
-                rename,
-                compare,
+                arguments,
                 &mut self.top_level,
                 &mut self.values,
             )?,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -108,10 +108,12 @@ impl VM {
         _env: SyntaxEnvironment,
         location: Location,
     ) -> Result<Datum> {
+        let form_value = Value::from_datum(&datum, &mut self.values);
+
         if let Some(datum) = Datum::from_value(
             &Instance::interpret_expander(
                 procedure,
-                &Value::syntax(datum.clone()),
+                &form_value,
                 arguments,
                 &mut self.context,
                 &mut self.top_level,

--- a/src/vm/byte_code/chunk.rs
+++ b/src/vm/byte_code/chunk.rs
@@ -46,6 +46,12 @@ impl Chunk {
         self.lines.push((from, to, line));
     }
 
+    // TODO: deduplicate constants
+    // Since they're constant it's fine to have multiple references to the same constant
+    // The idea here is that we don't use the chunk in code generation directly.
+    // Instead we use a chunk-builder, that in the end creates the chunk.
+    // The chunk-builder, doesn't store the constants in a vector but rather in a map<value, offset>.
+    // When the chunk is created, the builder creates a vector with the correct data in it then.
     pub fn add_constant(&mut self, value: Value) -> ConstAddressType {
         self.constants.push(value);
         (self.constants.len() - 1) as ConstAddressType

--- a/src/vm/instance.rs
+++ b/src/vm/instance.rs
@@ -15,15 +15,17 @@
 /// Examples:
 /// ```
 /// use braces::vm::instance::Instance;
-/// use braces::vm::{value, global::TopLevel};
+/// use braces::vm::{value, global::TopLevel, VM};
 /// use braces::compiler::{source::StringSource, Compiler};
+/// use braces::vm::scheme::ffi::VmContext;
 /// let mut source = StringSource::new("(define (id x) x) (id #t)");
 /// let mut compiler  = Compiler::new();
 /// let unit = compiler.compile(&mut source).unwrap();
 /// // Now interpret the unit
 /// let mut top_level = TopLevel::new();
 /// let mut values = value::Factory::default();
-/// let result = Instance::interpret(unit.closure, 256, &mut top_level, &mut values, false).unwrap();
+/// let mut ctx = VmContext::new();
+/// let result = Instance::interpret(unit.closure, 256, &mut ctx, &mut top_level, &mut values, false).unwrap();
 /// println!("{:#?}", result);
 /// ```
 ///

--- a/src/vm/scheme/core.rs
+++ b/src/vm/scheme/core.rs
@@ -39,67 +39,72 @@ pub fn register(vm: &mut VM) {
     register_core!(vm, "vector-ref", vector_ref, Arity::Exactly(2));
     register_core!(vm, "vector-cons", vector_cons, Arity::Exactly(2));
     register_core!(vm, "vector-append", vector_append, Arity::Exactly(2));
+    register_core!(vm, "gensym", gensym, Arity::Exactly(0));
 
     numbers::register(vm);
 }
 
+pub fn gensym(ctx: &mut VmContext, _args: Vec<Value>) -> FunctionResult<Access<Value>> {
+    Ok(ctx.gen_sym().into())
+}
+
 //  R7RS 6.1
 //  (eqv? obj1 obj2
-pub fn eqv(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn eqv(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (lhs, rhs) => Ok(Value::Bool(lhs.is_eqv(rhs)).into()),
     }
 }
 
-pub fn eq(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn eq(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (lhs, rhs) => Ok(Value::Bool(lhs.is_eq(rhs)).into()),
     }
 }
 
-pub fn equal(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn equal(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (lhs, rhs) => Ok(Value::Bool(lhs.is_equal(rhs)).into()),
     }
 }
 
 // predicates
-pub fn string_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn string_p(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::String(_) => Ok(Value::Bool(true).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
 
-pub fn symbol_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn symbol_p(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::Symbol(_) => Ok(Value::Bool(true).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
 
-pub fn char_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn char_p(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::Char(_) => Ok(Value::Bool(true).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
 
-pub fn list_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn list_p(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::ProperList(_) => Ok(Value::Bool(true).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
 
-pub fn null_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn null_p(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::ProperList(ls) => Ok(Value::Bool(ls.is_null()).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
 
-pub fn procedure_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn procedure_p(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::Procedure(_) => Ok(Value::Bool(true).into()),
         Value::Closure(_) => Ok(Value::Bool(true).into()),
@@ -107,24 +112,24 @@ pub fn procedure_p(args: Vec<Value>) -> FunctionResult<Access<Value>> {
     }
 }
 
-pub fn bool_not(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn bool_not(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match unary_procedure(&args)? {
         Value::Bool(v) => Ok(Value::Bool(!*v).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
 
-pub fn inspect(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn inspect(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     println!("Debug: {:?}", args.first().unwrap());
     Ok(Value::Unspecified.into())
 }
 
-pub fn list_make(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn list_make(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     let ls = args.into();
     Ok(Access::ByVal(Value::ProperList(ls)))
 }
 
-pub fn list_car(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn list_car(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     unary_procedure(&args).and_then(|v| match v {
         Value::ProperList(ls) => {
             if let Some(v) = ls.first() {
@@ -150,7 +155,7 @@ pub fn list_car(args: Vec<Value>) -> FunctionResult<Access<Value>> {
     })
 }
 
-pub fn list_cons(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn list_cons(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (v, Value::ProperList(elements)) => Ok(Value::ProperList(elements.cons(v.clone())).into()),
         (lhs, rhs) => Ok(Value::ImproperList(
@@ -161,7 +166,7 @@ pub fn list_cons(args: Vec<Value>) -> FunctionResult<Access<Value>> {
     }
 }
 
-pub fn list_append(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn list_append(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (Value::ProperList(lhs), Value::ProperList(rhs)) => {
             Ok(Value::ProperList(List::append(lhs, rhs)).into())
@@ -178,7 +183,7 @@ pub fn list_append(args: Vec<Value>) -> FunctionResult<Access<Value>> {
     }
 }
 
-pub fn vector_ref(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn vector_ref(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (Value::Vector(vector), Value::Number(index)) => {
             if let Some(idx) = index.to_usize() {
@@ -206,14 +211,14 @@ pub fn vector_ref(args: Vec<Value>) -> FunctionResult<Access<Value>> {
     }
 }
 
-pub fn vector_cons(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn vector_cons(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (v, Value::Vector(vector)) => Ok(Value::Vector(vector.cons(v.clone())).into()),
         (_, other) => Err(error::argument_error(other.clone(), "Expected vector")),
     }
 }
 
-pub fn vector_append(args: Vec<Value>) -> FunctionResult<Access<Value>> {
+pub fn vector_append(_ctx: &mut VmContext, args: Vec<Value>) -> FunctionResult<Access<Value>> {
     match binary_procedure(&args)? {
         (Value::Vector(lhs), Value::Vector(rhs)) => {
             Ok(Value::Vector(Vector::append(lhs, rhs)).into())

--- a/src/vm/scheme/ffi.rs
+++ b/src/vm/scheme/ffi.rs
@@ -1,4 +1,3 @@
-use crate::compiler::frontend::reader::datum::Datum;
 use crate::vm::value::{error, procedure::Arity};
 use crate::vm::value::{Factory, Value};
 use thiserror::Error;

--- a/src/vm/scheme/ffi.rs
+++ b/src/vm/scheme/ffi.rs
@@ -1,6 +1,6 @@
 use crate::compiler::frontend::reader::datum::Datum;
-use crate::vm::value::Value;
 use crate::vm::value::{error, procedure::Arity};
+use crate::vm::value::{Factory, Value};
 use thiserror::Error;
 
 pub type FunctionResult<T> = std::result::Result<T, error::RuntimeError>;
@@ -21,6 +21,27 @@ trait ToScheme {
 impl ToScheme for bool {
     fn to_scheme(&self) -> Value {
         Value::Bool(self.clone())
+    }
+}
+
+#[derive(Debug)]
+pub struct VmContext {
+    symbol_counter: u64,
+    values: Factory,
+}
+
+impl VmContext {
+    pub fn new() -> Self {
+        Self {
+            values: Factory::default(),
+            symbol_counter: 180,
+        }
+    }
+    pub fn gen_sym(&mut self) -> Value {
+        let next_count = self.symbol_counter;
+        let sym = self.values.symbol(format!("#:G{}", next_count));
+        self.symbol_counter += 1;
+        sym
     }
 }
 

--- a/src/vm/scheme/ffi.rs
+++ b/src/vm/scheme/ffi.rs
@@ -46,15 +46,9 @@ impl VmContext {
 }
 
 // Helpers
-pub fn explicit_rename_transformer(args: &Vec<Value>) -> FunctionResult<(&Datum, &Value, &Value)> {
+pub fn explicit_rename_transformer(args: &Vec<Value>) -> FunctionResult<(&Value, &Value, &Value)> {
     match &args[..] {
-        [first, second, third] => match first {
-            Value::Syntax(datum) => Ok((datum, second, third)),
-            _ => Err(error::argument_error(
-                first.clone(),
-                "expected syntax object",
-            )),
-        },
+        [first, second, third] => Ok((first, second, third)),
         _ => Err(error::arity_mismatch(Arity::Exactly(3), args.len())),
     }
 }

--- a/src/vm/scheme/ffi.rs
+++ b/src/vm/scheme/ffi.rs
@@ -45,12 +45,6 @@ impl VmContext {
 }
 
 // Helpers
-pub fn explicit_rename_transformer(args: &Vec<Value>) -> FunctionResult<(&Value, &Value, &Value)> {
-    match &args[..] {
-        [first, second, third] => Ok((first, second, third)),
-        _ => Err(error::arity_mismatch(Arity::Exactly(3), args.len())),
-    }
-}
 
 pub fn ternary_procedure(args: &Vec<Value>) -> FunctionResult<(&Value, &Value, &Value)> {
     match &args[..] {

--- a/src/vm/scheme/writer.rs
+++ b/src/vm/scheme/writer.rs
@@ -38,6 +38,7 @@ impl Writer {
             Value::Bool(true) => "#t".to_string(),
             Value::Bool(false) => "#f".to_string(),
             Value::Symbol(s) => self.write_symbol(s.as_str()),
+            Value::UninternedSymbol(s) => self.write_symbol(s.as_str()),
             Value::Char(c) => self.write_char(*c),
             Value::Number(num) => self.write_number(num),
             Value::String(s) => self.write_string(s.as_ref()),

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -12,6 +12,7 @@ use crate::vm::scheme::writer::Writer;
 use crate::vm::value::number::real::RealNumber;
 
 use self::symbol::Symbol;
+use crate::compiler::frontend::syntax;
 use crate::vm::value::byte_vector::ByteVector;
 use crate::vm::value::vector::Vector;
 
@@ -41,6 +42,7 @@ pub enum Value {
     Syntax(Datum),
     Bool(bool),
     Symbol(Symbol),
+    UninternedSymbol(syntax::symbol::Symbol),
     Char(char),
     Number(number::Number),
     String(string::String),
@@ -68,7 +70,7 @@ impl Value {
     pub fn from_datum(v: &Datum, values: &mut Factory) -> Self {
         match v {
             Datum::Char(c, _) => Self::Char(c.clone()),
-            Datum::Symbol(s, _) => values.symbol(s.as_str()),
+            Datum::Symbol(s, _) => Value::UninternedSymbol(s.clone()),
             Datum::String(s, _) => values.string(s),
             Datum::Number(n, _) => Self::Number(n.clone()),
             Datum::Bool(v, _) => Self::Bool(v.clone()),

--- a/src/vm/value/closure.rs
+++ b/src/vm/value/closure.rs
@@ -68,6 +68,12 @@ impl From<procedure::native::Procedure> for Closure {
     }
 }
 
+impl From<Closure> for procedure::Procedure {
+    fn from(cl: Closure) -> Self {
+        procedure::Procedure::Native(cl.proc.clone())
+    }
+}
+
 impl SchemeEqual<Closure> for Closure {
     fn is_eq(&self, other: &Closure) -> bool {
         Rc::ptr_eq(&self.proc, &other.proc)

--- a/src/vm/value/list.rs
+++ b/src/vm/value/list.rs
@@ -102,6 +102,13 @@ impl List {
         self.at(3)
     }
 
+    pub fn cdr(&self) -> Option<List> {
+        match self {
+            Self::Nil => None,
+            Self::Cons(elements) => Some(Self::from(elements.skip(1))),
+        }
+    }
+
     pub fn at(&self, i: usize) -> Option<&Reference<Value>> {
         match self {
             List::Nil => None,

--- a/src/vm/value/procedure.rs
+++ b/src/vm/value/procedure.rs
@@ -86,7 +86,7 @@ impl SchemeEqual<Procedure> for Procedure {
 }
 
 impl HasArity for Procedure {
-    fn arity<'a>(&'a self) -> &'a Arity {
+    fn arity(&self) -> &Arity {
         match self {
             Procedure::Native(proc) => &proc.arity,
             Procedure::Foreign(proc) => &proc.arity,
@@ -95,7 +95,7 @@ impl HasArity for Procedure {
 }
 
 impl HasArity for std::rc::Rc<Procedure> {
-    fn arity<'a>(&'a self) -> &'a Arity {
+    fn arity(&self) -> &Arity {
         match &**self {
             Procedure::Native(proc) => &proc.arity,
             Procedure::Foreign(proc) => &proc.arity,

--- a/src/vm/value/procedure/foreign.rs
+++ b/src/vm/value/procedure/foreign.rs
@@ -1,10 +1,10 @@
 use super::{Arity, HasArity};
-use crate::vm::scheme::ffi::FunctionResult;
+use crate::vm::scheme::ffi::{FunctionResult, VmContext};
 use crate::vm::value::access::Access;
 use crate::vm::value::equality::SchemeEqual;
 use crate::vm::value::Value;
 
-pub type ProcedureImpl = dyn Fn(Vec<Value>) -> FunctionResult<Access<Value>>;
+pub type ProcedureImpl = dyn Fn(&mut VmContext, Vec<Value>) -> FunctionResult<Access<Value>>;
 
 pub struct Procedure {
     pub name: String,
@@ -16,7 +16,7 @@ impl Procedure {
     pub fn new<S, I>(name: S, op: I, arity: Arity) -> Self
     where
         S: Into<String>,
-        I: 'static + Fn(Vec<Value>) -> FunctionResult<Access<Value>>,
+        I: 'static + Fn(&mut VmContext, Vec<Value>) -> FunctionResult<Access<Value>>,
     {
         Self {
             name: name.into(),
@@ -25,8 +25,12 @@ impl Procedure {
         }
     }
 
-    pub fn call(&self, arguments: Vec<Value>) -> FunctionResult<Access<Value>> {
-        (self.proc)(arguments)
+    pub fn call(
+        &self,
+        ctx: &mut VmContext,
+        arguments: Vec<Value>,
+    ) -> FunctionResult<Access<Value>> {
+        (self.proc)(ctx, arguments)
     }
 }
 

--- a/tests/compiler/macro_expansion_tests.rs
+++ b/tests/compiler/macro_expansion_tests.rs
@@ -9,8 +9,8 @@ fn lowlevel_macro_transformer() {
         &mut vm,
         r#"
         (define-syntax my-cons 
-          (lowlevel-macro-transformer 
-            (lambda (form) 
+          (er-macro-transformer 
+            (lambda (form rename compare) 
                (let ((args (cdr form)))
                  `(cons ,(car args) ,(cadr args))))))
                  

--- a/tests/compiler/macro_expansion_tests.rs
+++ b/tests/compiler/macro_expansion_tests.rs
@@ -9,8 +9,8 @@ fn lowlevel_macro_transformer() {
         &mut vm,
         r#"
         (define-syntax my-cons 
-          (er-macro-transformer 
-            (lambda (form rename compare) 
+          (lowlevel-macro-transformer 
+            (lambda (form) 
                (let ((args (cdr form)))
                  `(cons ,(car args) ,(cadr args))))))
                  

--- a/tests/compiler/macro_expansion_tests.rs
+++ b/tests/compiler/macro_expansion_tests.rs
@@ -5,11 +5,17 @@ use braces::vm::VM;
 fn lowlevel_macro_transformer() {
     let mut vm = VM::default();
 
-    // the parameter called `if` shadows the core if form
     let result = run_code(
         &mut vm,
-        "(define-syntax my-macro (lowlevel-macro-transformer (lambda (form) `(cons 1 2)))) (my-macro))"
-    ).unwrap();
+        r#"
+        (define-syntax my-cons 
+          (lowlevel-macro-transformer 
+            (lambda (form) 
+               `(cons ,(car form) ,(cadr form))))) 
+        (my-cons 1 2)
+        "#,
+    )
+    .unwrap();
 
     assert_eq!(
         result,

--- a/tests/compiler/macro_expansion_tests.rs
+++ b/tests/compiler/macro_expansion_tests.rs
@@ -1,0 +1,19 @@
+use crate::helpers::*;
+use braces::vm::VM;
+
+#[test]
+fn lowlevel_macro_transformer() {
+    let mut vm = VM::default();
+
+    // the parameter called `if` shadows the core if form
+    let result = run_code(
+        &mut vm,
+        "(define-syntax my-macro (lowlevel-macro-transformer (lambda (form) `(cons 1 2)))) (my-macro))"
+    ).unwrap();
+
+    assert_eq!(
+        result,
+        vm.values
+            .improper_list(vec![vm.values.real(1)], vm.values.real(2))
+    );
+}

--- a/tests/compiler/macro_expansion_tests.rs
+++ b/tests/compiler/macro_expansion_tests.rs
@@ -11,7 +11,9 @@ fn lowlevel_macro_transformer() {
         (define-syntax my-cons 
           (lowlevel-macro-transformer 
             (lambda (form) 
-               `(cons ,(car form) ,(cadr form))))) 
+               (let ((args (cdr form)))
+                 `(cons ,(car args) ,(cadr args))))))
+                 
         (my-cons 1 2)
         "#,
     )

--- a/tests/compiler/mod.rs
+++ b/tests/compiler/mod.rs
@@ -1,1 +1,2 @@
+pub mod macro_expansion_tests;
 pub mod smoke_tests;


### PR DESCRIPTION
This adds a lowlevel; macro facility ala `defmacro`.  It introduces procedural macros and also lays the foundation for other procedural macros like explicit renaming, which we want to converge to evntually.

The following code demonstrates that.

```scheme
(define my-cons
  (lowlevel-macro-transformer 
    (lambda (form) 
       (let ((args (cdr form)))
         `(cons ,(car args) ,(cadr args)))))

(my-cons 1 2)
```


## Limitations 
* macros don’t play well with the REPL. The Macro definitions are lost after the evaluation. One idea would be to preserve the syntax environment after each parse. 
* source locations don’t play well with the expansion procedures. The expander converts the Datum to a value and back. The source location is stripped off. One idea here is to have syntax objects as values instead of lists.