### PR TITLE
Fix gensum

### DIFF
--- a/src/vm/instance.rs
+++ b/src/vm/instance.rs
@@ -89,12 +89,7 @@ pub struct Instance<'a> {
     open_up_values: FxHashMap<AddressType, Reference<Value>>,
     // enable cycle debugging
     settings: Options,
-
-    symbol_counter: u64,
 }
-
-// symbols beneath are reserved
-const SYMBOL_COUNTER_START: u64 = 180;
 
 // TODO: Optimize for performance
 // Likely candidates for optimizations are the stack(s)
@@ -128,7 +123,6 @@ impl<'a> Instance<'a> {
             active_frame: std::ptr::null_mut(),
             open_up_values,
             settings,
-            symbol_counter: SYMBOL_COUNTER_START,
         }
     }
 
@@ -166,11 +160,8 @@ impl<'a> Instance<'a> {
         }
     }
 
-    pub fn gen_sym(&mut self) -> Value {
-        let next_count = self.symbol_counter;
-        let sym = self.values.symbol(format!("#:G{}", next_count));
-        self.symbol_counter += 1;
-        sym
+    pub fn gensym(&mut self) -> Value {
+        self.values.gensym(None)
     }
 
     pub fn load_file(&mut self, path: &std::path::Path) -> Result<Access<Value>> {

--- a/src/vm/scheme/core.rs
+++ b/src/vm/scheme/core.rs
@@ -63,7 +63,7 @@ pub fn load_file(vm: &mut Instance, args: Vec<Value>) -> FunctionResult<Access<V
 }
 
 pub fn gensym(vm: &mut Instance, _args: Vec<Value>) -> FunctionResult<Access<Value>> {
-    Ok(vm.gen_sym().into())
+    Ok(vm.gensym().into())
 }
 
 //  R7RS 6.1

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -157,6 +157,8 @@ impl SchemeEqual<Value> for Value {
     }
 }
 
+const SYMBOL_COUNTER_START: u64 = 180;
+
 #[derive(Debug, Clone)]
 pub struct Factory {
     strings: StringTable,
@@ -164,6 +166,7 @@ pub struct Factory {
     false_value: Value,
     nil_value: Value,
     unspecified: Value,
+    symbol_counter: u64,
 }
 
 impl Default for Factory {
@@ -174,6 +177,7 @@ impl Default for Factory {
             false_value: Value::Bool(false),
             nil_value: Value::ProperList(list::List::Nil),
             unspecified: Value::Unspecified,
+            symbol_counter: SYMBOL_COUNTER_START,
         }
     }
 }
@@ -206,6 +210,12 @@ impl Factory {
     pub fn sym<T: Into<std::string::String>>(&mut self, v: T) -> Symbol {
         let k = self.strings.get_or_intern(v.into());
         Symbol(k)
+    }
+
+    pub fn gensym(&mut self, prefix: Option<&str>) -> Value {
+        let s = format!("#:G{}{}", prefix.unwrap_or(""), self.symbol_counter);
+
+        self.symbol(s)
     }
 
     pub fn symbol<T: Into<std::string::String>>(&mut self, v: T) -> Value {


### PR DESCRIPTION
Fixes #38 

This moves gensym into the value factory which exists only once per VM